### PR TITLE
Disable Lint/UselessConstantScoping cop for DISPATCH constant

### DIFF
--- a/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
+++ b/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
@@ -197,7 +197,9 @@ module MultiTenant
       end
     end
 
+    # rubocop:disable Lint/UselessConstantScoping
     DISPATCH = dispatch_cache
+    # rubocop:enable Lint/UselessConstantScoping
 
     # rubocop:disable Naming/AccessorMethodName
     def get_dispatch_cache

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -149,9 +149,11 @@ module MultiTenant
       MultiTenant.multi_tenant_model_for_table(table_name).present?
     end
 
+    # rubocop:disable Lint/UselessConstantScoping
     DISPATCH = Hash.new do |hash, klass|
       hash[klass] = "visit_#{(klass.name || '').gsub('::', '_')}"
     end
+    # rubocop:enable Lint/UselessConstantScoping
 
     def dispatch
       DISPATCH


### PR DESCRIPTION
This change addresses the following RuboCop Lint/UselessConstantScoping offense, which was introduced in RuboCop [v1.72.0](https://github.com/rubocop/rubocop/blob/70bc4884967c6bcf54e43ec99275d103cdac03a0/relnotes/v1.72.0.md).

Because of this offense, the static-checks workflow fails:
https://github.com/kufu/activerecord-multi-tenant/actions/runs/14637409931/job/41071660759

For now, we can ignore it in the same way as elsewhere.

I can change DISPATCH to a private constant but this will be a breaking change.