### PR TITLE
Fix RuboCop warnings

### DIFF
--- a/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
+++ b/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
@@ -14,6 +14,8 @@ module MultiTenant
       @block.call obj
     end
 
+    # rubocop:disable Naming/MethodName
+
     def unary(obj)
       visit obj.expr
     end
@@ -47,8 +49,6 @@ module MultiTenant
     alias visit_Arel_Nodes_Max    function
     alias visit_Arel_Nodes_Min    function
     alias visit_Arel_Nodes_Sum    function
-
-    # rubocop:disable Naming/MethodName
 
     def visit_Arel_Nodes_NamedFunction(obj)
       visit obj.name

--- a/lib/activerecord-multi-tenant/habtm.rb
+++ b/lib/activerecord-multi-tenant/habtm.rb
@@ -7,9 +7,9 @@
 module ActiveRecord
   module Associations
     module ClassMethods
-      # rubocop:disable Naming/PredicateName
+      # rubocop:disable Naming/PredicatePrefix
       def has_and_belongs_to_many_with_tenant(name, scope = nil, **options, &extension)
-        # rubocop:enable Naming/PredicateName
+        # rubocop:enable Naming/PredicatePrefix
         has_and_belongs_to_many_without_tenant(name, scope, **options, &extension)
 
         middle_reflection = _reflect_on_association(name.to_s).through_reflection

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -136,12 +136,12 @@ module MultiTenant
       end
     end
 
-    # rubocop:enable Naming/MethodName
-
     alias visit_Arel_Nodes_FullOuterJoin visit_Arel_Nodes_OuterJoin
     alias visit_Arel_Nodes_RightOuterJoin visit_Arel_Nodes_OuterJoin
 
     alias visit_ActiveModel_Attribute terminal
+
+    # rubocop:enable Naming/MethodName
 
     private
 

--- a/spec/activerecord-multi-tenant/controller_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/controller_extensions_spec.rb
@@ -9,6 +9,7 @@ describe 'Controller Extensions', type: :controller do
 
   class ApplicationController < ActionController::Base
     include Rails.application.routes.url_helpers
+
     set_current_tenant_through_filter
 
     before_action :your_method_that_finds_the_current_tenant
@@ -35,6 +36,7 @@ describe 'Controller Extensions', type: :controller do
 
   class APIApplicationController < ActionController::API
     include Rails.application.routes.url_helpers
+
     set_current_tenant_through_filter
     before_action :your_method_that_finds_the_current_tenant
 


### PR DESCRIPTION
This PR mainly includes minor code style and RuboCop directive adjustments to improve clarity and maintainability, particularly regarding method naming conventions. There are also small formatting changes in the test files.

Rubocop directive and code style adjustments:

* Updated RuboCop comments in `lib/activerecord-multi-tenant/habtm.rb` to use `Naming/PredicatePrefix` instead of the deprecated `Naming/PredicateName` directive.
* Moved or adjusted `rubocop:disable Naming/MethodName` and `rubocop:enable Naming/MethodName` comments in `lib/activerecord-multi-tenant/arel_visitors_depth_first.rb` and `lib/activerecord-multi-tenant/query_rewriter.rb` to better align with the methods they affect.

Formatting improvements in tests:

* Added blank lines for readability in controller classes within `spec/activerecord-multi-tenant/controller_extensions_spec.rb`.