### PR TITLE
Avoid using git for `spec.files`

### DIFF
--- a/activerecord-multi-tenant.gemspec
+++ b/activerecord-multi-tenant.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0.0'
   spec.metadata = { 'rubygems_mfa_required' => 'true' }
 
-  spec.files = `git ls-files`.split("\n")
+  spec.files = Dir['lib/**/*', 'LICENSE', 'README.md', 'CHANGELOG.md']
   spec.require_paths = ['lib']
   spec.homepage = 'https://github.com/citusdata/activerecord-multi-tenant'
   spec.license = 'MIT'


### PR DESCRIPTION
Changed the `spec.files` assignment in `activerecord-multi-tenant.gemspec` to use pure ruby `Dir` for selecting files instead of git command.

cf.
https://github.com/rubygems/rubygems/issues/4047#issuecomment-3271166975
https://docs.rubocop.org/rubocop-packaging/cops_packaging.html#packaginggemspecgit