### PR TITLE
Remove unused Appraisals

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,17 +1,5 @@
 # frozen_string_literal: true
 
-appraise 'rails-6.0' do
-  gem 'rails', '~> 6.0.3'
-end
-
-appraise 'rails-6.1' do
-  gem 'rails', '~> 6.1.0'
-end
-
-appraise 'rails-7.0' do
-  gem 'rails', '~> 7.0.0'
-end
-
 appraise 'rails-7.1' do
   gem 'rails', '~> 7.1.0'
 end
@@ -22,28 +10,4 @@ end
 
 appraise 'rails-8.0' do
   gem 'rails', '~> 8.0.0'
-end
-
-appraise 'active-record-6.0' do
-  gem 'activerecord', '~> 6.0.3'
-end
-
-appraise 'active-record-6.1' do
-  gem 'activerecord', '~> 6.1.0'
-end
-
-appraise 'active-record-7.0' do
-  gem 'activerecord', '~> 7.0.0'
-end
-
-appraise 'active-record-7.1' do
-  gem 'activerecord', '~> 7.1.0'
-end
-
-appraise 'active-record-7.2' do
-  gem 'activerecord', '~> 7.2.0'
-end
-
-appraise 'active-record-8.0' do
-  gem 'activerecord', '~> 8.0.0'
 end


### PR DESCRIPTION
Since this gem supports only Rails >= 7.1 (https://github.com/kufu/activerecord-multi-tenant/pull/10), we don't need`rails-6.0`, `rails-6.1`, `rails-7.0` .

Also, we don't use `active-record-*` appraisals. 