### PR TITLE
Remove Arel::Visitors::DepthFirst / Add Rails 8.1 support for Arel::Nodes::Function

### DIFF
--- a/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
+++ b/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
@@ -39,29 +39,50 @@ module MultiTenant
     alias visit_Arel_Nodes_OptimizerHints    unary
     alias visit_Arel_Nodes_ValuesList        unary
 
-    def function(obj)
-      visit obj.expressions
-      visit obj.alias
-      visit obj.distinct
+    # From Rails 8.1, Arel::Nodes::Function no longer has an alias attribute
+    # cf. https://github.com/rails/rails/pull/54824
+    if ActiveRecord.gem_version < Gem::Version.new('8.1')
+      def function(obj)
+        visit obj.expressions
+        visit obj.alias
+        visit obj.distinct
+      end
+
+      def visit_Arel_Nodes_NamedFunction(obj)
+        visit obj.name
+        visit obj.expressions
+        visit obj.distinct
+        visit obj.alias
+      end
+
+      def visit_Arel_Nodes_Count(obj)
+        visit obj.expressions
+        visit obj.alias
+        visit obj.distinct
+      end
+    else
+      def function(obj)
+        visit obj.expressions
+        visit obj.distinct
+      end
+
+      def visit_Arel_Nodes_NamedFunction(obj)
+        visit obj.name
+        visit obj.expressions
+        visit obj.distinct
+      end
+
+      def visit_Arel_Nodes_Count(obj)
+        visit obj.expressions
+        visit obj.distinct
+      end
     end
+
     alias visit_Arel_Nodes_Avg    function
     alias visit_Arel_Nodes_Exists function
     alias visit_Arel_Nodes_Max    function
     alias visit_Arel_Nodes_Min    function
     alias visit_Arel_Nodes_Sum    function
-
-    def visit_Arel_Nodes_NamedFunction(obj)
-      visit obj.name
-      visit obj.expressions
-      visit obj.distinct
-      visit obj.alias
-    end
-
-    def visit_Arel_Nodes_Count(obj)
-      visit obj.expressions
-      visit obj.alias
-      visit obj.distinct
-    end
 
     def visit_Arel_Nodes_Case(obj)
       visit obj.case

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -60,11 +60,7 @@ module MultiTenant
     end
   end
 
-  class ArelTenantVisitor < if Arel::Visitors.const_defined?(:DepthFirst)
-                              Arel::Visitors::DepthFirst
-                            else
-                              ::MultiTenant::ArelVisitorsDepthFirst
-                            end
+  class ArelTenantVisitor < ArelVisitorsDepthFirst
     def initialize(arel)
       super(proc {})
       @statement_node_id = nil

--- a/spec/activerecord-multi-tenant/query_rewriter_spec.rb
+++ b/spec/activerecord-multi-tenant/query_rewriter_spec.rb
@@ -365,4 +365,48 @@ describe 'Query Rewriter' do
       expect(format_sql(update_query)).to eq(format_sql(expected_query))
     end
   end
+
+  context 'when using functions / named functions with Arel' do
+    let!(:account) { Account.create!(name: 'Test Account') }
+    let!(:projects) { 3.times { |i| Project.create!(name: "Project #{i + 1}", account: account) } }
+
+    it 'handles COUNT in HAVING clause with tenant enforcement' do
+      table = Project.arel_table
+
+      result = MultiTenant.with(account) do
+        Project.select(table[:account_id])
+               .group(table[:account_id])
+               .having(table[:id].count.gt(2))
+               .to_a
+      end
+
+      expect(result.length).to eq(1)
+      expect(result.first.account_id).to eq(account.id)
+    end
+
+    it 'handles SUM in HAVING clause with tenant enforcement' do
+      table = Project.arel_table
+
+      result = MultiTenant.with(account) do
+        Project.select(table[:account_id])
+               .group(table[:account_id])
+               .having(table[:id].sum.gt(0))
+               .to_a
+      end
+
+      expect(result.length).to eq(1)
+    end
+
+    it 'handles NamedFunction in WHERE clause with tenant enforcement' do
+      table = Project.arel_table
+      lower_func = Arel::Nodes::NamedFunction.new('LOWER', [table[:name]])
+
+      result = MultiTenant.with(account) do
+        Project.where(lower_func.eq('project 1')).to_a
+      end
+
+      expect(result.length).to eq(1)
+      expect(result.first.name).to eq('Project 1')
+    end
+  end
 end


### PR DESCRIPTION
- Arel::Visitors::DepthFirst was already removed in [this PR](https://github.com/rails/rails/pull/36492?utm_source=chatgpt.com). Since we only support Rails 7.1 and later, we do not need to handle it.

- From Rails 8.1, `Arel::Nodes::Function` no longer has an alias attribute; aliasing is now handled via `AliasPredication#as`(https://github.com/rails/rails/pull/54824).