### PR TITLE
Fix update_all to correctly handle Arel nodes

### DIFF
--- a/lib/activerecord-multi-tenant/relation_extension.rb
+++ b/lib/activerecord-multi-tenant/relation_extension.rb
@@ -23,9 +23,21 @@ module Arel
       # Call the original update_all method if the current tenant is identified by an ID
       return super if model.nil? || MultiTenant.current_tenant_is_id? || MultiTenant.current_tenant.nil?
 
+      if updates.is_a?(Hash)
+        if klass.locking_enabled? &&
+           !updates.key?(klass.locking_column) &&
+           !updates.key?(klass.locking_column.to_sym)
+          attr = table[klass.locking_column]
+          updates[attr.name] = _increment_attribute(attr)
+        end
+        values = _substitute_values(updates)
+      else
+        values = Arel.sql(klass.sanitize_sql_for_assignment(updates, table.name))
+      end
+
       stmt = Arel::UpdateManager.new
       stmt.table(table)
-      stmt.set Arel.sql(klass.send(:sanitize_sql_for_assignment, updates))
+      stmt.set values
       stmt.wheres = [generate_in_condition_subquery]
 
       klass.connection.update(stmt, "#{klass} Update All").tap { reset }

--- a/spec/activerecord-multi-tenant/query_rewriter_spec.rb
+++ b/spec/activerecord-multi-tenant/query_rewriter_spec.rb
@@ -67,6 +67,8 @@ describe 'Query Rewriter' do
       @queries.each do |actual_query|
         next unless actual_query.include?('UPDATE "projects" SET "name"')
 
+        actual_query = actual_query.gsub('$1', "'New Name'")
+
         expect(format_sql(actual_query)).to eq(format_sql(expected_query.gsub(':account_id', account.id.to_s)))
       end
     end
@@ -102,6 +104,8 @@ describe 'Query Rewriter' do
 
       @queries.each do |actual_query|
         next unless actual_query.include?('UPDATE "projects" SET "name"')
+
+        actual_query = actual_query.gsub('$1', "'#{new_name}'").gsub('$2', limit.to_s)
 
         expect(format_sql(actual_query.gsub('$1',
                                             limit.to_s)).strip).to eq(format_sql(expected_query).strip)
@@ -214,6 +218,40 @@ describe 'Query Rewriter' do
     end
   end
 
+  context 'when update_all with Arel nodes' do
+    let!(:account) { Account.create!(name: 'Test Account') }
+    let!(:project) { Project.create(name: 'Project 1', account: account) }
+    let!(:comment) do
+      Comment.create!(account: account, commentable: project, counter: 0)
+    end
+
+    it 'increment! works correctly with tenant scoping' do
+      MultiTenant.with(account) do
+        comment.increment!(:counter)
+      end
+      expect(comment.reload.counter).to eq(1)
+    end
+
+    it 'decrement! works correctly with tenant scoping' do
+      comment.update!(counter: 5)
+      MultiTenant.with(account) do
+        comment.decrement!(:counter)
+      end
+      expect(comment.reload.counter).to eq(4)
+    end
+
+    it 'update_all with Hash updates generates correct SQL with tenant scoping' do
+      MultiTenant.with(account) do
+        Comment.update_all(counter: 1)
+      end
+
+      update_query = @queries.find { |q| q.include?('UPDATE "comments"') }
+      expect(update_query).to be_present
+      expect(update_query).to include('account_id')
+      expect(comment.reload.counter).to eq(1)
+    end
+  end
+
   context 'when using non-multi-tenant model' do
     let!(:account1) { Account.create!(name: 'Test Account') }
     let!(:account2) { Account.create!(name: 'Test Account2') }
@@ -310,6 +348,9 @@ describe 'Query Rewriter' do
       # Verify the generated SQL is correct for composite primary keys
       update_query = @queries.find { |q| q.include?('UPDATE "composite_key_models"') }
       expect(update_query).to be_present
+
+      # Extract parameterized values and replace placeholders
+      update_query = update_query.gsub('$1', "'Updated Name'")
 
       expected_query = <<~SQL.strip
         UPDATE "composite_key_models"

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -97,6 +97,7 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :account_id, :integer
     t.column :commentable_id, :integer
     t.column :commentable_type, :string
+    t.column :counter, :integer, default: 0
   end
 
   create_table :partition_key_not_model_tasks, force: true, partition_key: :non_model_id do |t|


### PR DESCRIPTION
## Summary

Fix `update_all` to correctly handle updates containing Arel nodes.

## Background

The current `update_all` implementation serializes update values using `sanitize_sql_for_assignment`.
However, this method cannot convert Arel nodes (e.g., `Arel::Nodes::Addition`) to SQL, causing runtime errors in the following cases:

- `increment!` / `decrement!` (internally generates Arel expressions like `column + 1`)
- `counter_culture` gem (uses Arel expressions for counter updates)

This issue has also been reported in the upstream repository (citusdata/activerecord-multi-tenant#282).

## Changes

Aligned with Rails' own `update_all` implementation by using `_substitute_values` for Hash updates.

- **Hash updates**: Uses `_substitute_values` to preserve Arel nodes as-is and convert other values to bind parameters
- **String updates**: Processed with `sanitize_sql_for_assignment` as before
- **Optimistic Locking**: Reproduces the same `lock_version` auto-increment behavior as Rails

### Reference: Rails implementation

https://github.com/rails/rails/blob/8-1-stable/activerecord/lib/active_record/relation.rb#L615-L625

## Note

Due to the use of `_substitute_values`, the generated SQL now uses bind parameters (`$1`, `$2`...) instead of literal values.
Existing SQL string comparison tests have been adjusted accordingly.