### PR TITLE
Sidekiq 7.3.10 does not use AfterCommitEverywhere

### DIFF
--- a/spec/activerecord-multi-tenant/sidekiq_transaction_aware_client_spec.rb
+++ b/spec/activerecord-multi-tenant/sidekiq_transaction_aware_client_spec.rb
@@ -58,7 +58,7 @@ describe MultiTenant, 'SidekiqTransactionAwareClient' do
       expect(TestWorker.jobs[-1]).to_not be_key('multi_tenant')
     end
 
-    if Gem::Version.new('7.3.0') <= Sidekiq.gem_version && Sidekiq.gem_version < Gem::Version.new('8.0.0')
+    if Gem::Version.new('7.3.0') <= Sidekiq.gem_version && Sidekiq.gem_version < Gem::Version.new('7.3.10')
       it 'Sidekiq gem has not changed' do
         meth = Sidekiq::TransactionAwareClient.instance_method(:push)
 


### PR DESCRIPTION
Thanks to https://github.com/sidekiq/sidekiq/pull/6814, Sidekiq 7.3.10 was released with support for ActiveRecord transactions.

Our tests started failing because we had assumed that versions below 8.0 would always use AfterCommitEverywhere.
We therefore need to update the version condition in our code.