### PR TITLE
Fix RuboCop static check offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,9 @@ Style/Documentation:
 Style/DocumentDynamicEvalDefinition:
   Enabled: false
 
+Style/OneClassPerFile:
+  Enabled: false
+
 Metrics/BlockLength:
   Max: 650
 

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -304,7 +304,7 @@ module MultiTenant
                           node.source.right
                         end
 
-            node_list.select { |n| n.is_a? Arel::Nodes::Join }.each do |node_join|
+            node_list.grep(Arel::Nodes::Join).each do |node_join|
               next unless node_join.right
 
               relation_right, relation_left = relations_from_node_join(node_join)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,7 +72,6 @@ RSpec.configure do |config|
   end
 end
 
-# rubocop:disable Lint/UnusedMethodArgument
 # changing the name of the parameter breaks tests
 def with_belongs_to_required_by_default(&block)
   default_value = ActiveRecord::Base.belongs_to_required_by_default
@@ -81,5 +80,5 @@ def with_belongs_to_required_by_default(&block)
 ensure
   ActiveRecord::Base.belongs_to_required_by_default = default_value
 end
-# rubocop:enable Lint/UnusedMethodArgument
+
 require 'schema'


### PR DESCRIPTION
## Summary

Fix a few static check offenses reported by RuboCop and disable a cop that does not fit this repository's layout.

## Changes

- **`Style/SelectByKind`** (`lib/activerecord-multi-tenant/query_rewriter.rb`): Replace `select { |n| n.is_a? Arel::Nodes::Join }` with the more idiomatic `grep(Arel::Nodes::Join)`.
- **`Lint/RedundantCopDisableDirective`** (`spec/spec_helper.rb`): Remove the now-unnecessary `# rubocop:disable/enable Lint/UnusedMethodArgument` pair around `with_belongs_to_required_by_default` — the directive is no longer needed since the method does use its block argument.
- **`Style/OneClassPerFile`** (`.rubocop.yml`): Disable this cop. Several files in this gem intentionally define multiple small classes/modules together (e.g. monkeypatch bundles), and splitting them up would hurt readability without practical benefit.
